### PR TITLE
chore: set featurescript linguist overrides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Override GitHub Linguist language detection for FeatureScript
+*.fs linguist-language=FeatureScript
+*.fs linguist-detectable

--- a/linguist-languages.yml
+++ b/linguist-languages.yml
@@ -1,0 +1,3 @@
+FeatureScript:
+  type: programming
+  color: "#F29E39"


### PR DESCRIPTION
## Summary
- configure GitHub Linguist to treat `.fs` files as FeatureScript
- define FeatureScript language metadata for accurate detection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ec35252c83328b1a5636a5108370