### PR TITLE
Add guide for extending Query Variable Plus

### DIFF
--- a/QUERY_VARIABLE_PLUS_EXTENSION_GUIDE.md
+++ b/QUERY_VARIABLE_PLUS_EXTENSION_GUIDE.md
@@ -1,0 +1,29 @@
+# Query Variable Plus: Adding New Query Types
+
+This guide outlines how to extend **Query Variable Plus** with additional query types. It contrasts the Plus implementation with the standard **Query Variable** feature so future updates stay consistent with the existing patterns.
+
+## Key differences vs. Query Variable
+- **Expanded selection set**: Plus already supports `MATCHING_BODIES`, `ADJACENT`, and `GEOMETRY` selection types that are not present in the base feature. The SelectionType enum and its lowercase label map include these entries, and any new type must follow the same pattern. 【F:custom-features/queryVariablePlus.fs†L25-L84】【F:queryVariable.fs†L23-L73】
+- **Additional parameter blocks**: New selection types often require custom inputs in both `initialQueryPredicate` and `additionalQueryPredicate` (for array items). For example, adjacency selections add seed entities, adjacency type, and result entity options, while geometry selections capture a geometry type filter. Matching bodies reuse the body-seed branch used by OWNED_BY/EDGE_CONVEXITY. 【F:custom-features/queryVariablePlus.fs†L158-L240】【F:custom-features/queryVariablePlus.fs†L270-L342】
+- **Custom query builders**: The Plus feature maps new selection types to dedicated helper functions such as `adjacencySelection` and `qMatchingBodies`, keeping `mapSelectionTypeToQuery` readable. Any new selection should have a similar mapper entry and, if needed, a focused helper for validation or pre/post-processing. 【F:custom-features/queryVariablePlus.fs†L517-L629】
+
+## Implementation checklist for a new selection type
+1. **Add the enum entry**
+   - Insert the new selection type in `SelectionType` and the `SelectionTypeToLowercaseName` map so UI labels and computed parameters stay synchronized. Maintain the descriptive annotation style used by Plus. 【F:custom-features/queryVariablePlus.fs†L25-L84】
+2. **Collect inputs in both predicates**
+   - Extend `initialQueryPredicate` with annotated parameters (queries, enums, toggles) required by the new selection. Mirror the same fields in `additionalQueryPredicate`, prefixed with `addQ`. Reuse existing filters (`AllowMeshGeometry`, `AllowFlattenedGeometry`, entity filters) to match related cases when possible. 【F:custom-features/queryVariablePlus.fs†L158-L240】【F:custom-features/queryVariablePlus.fs†L270-L342】
+3. **Map the selection to a query**
+   - Update `mapSelectionTypeToQuery` with a switch arm that translates the new type into a Query expression. If the logic is involved (validation, clustering, or branching outputs), create a helper alongside `adjacencySelection`/`qMatchingBodies` to keep the switch concise. 【F:custom-features/queryVariablePlus.fs†L517-L629】
+4. **Handle additional-query metadata**
+   - The UI shows the lowercase selection name for each additional query via `faultyArrayParameterId` and `SelectionTypeToLowercaseName`. Ensure your new selection’s lowercase label reads well in “`#booleanOperation of #selection`” strings. No extra changes are needed if the enum map is updated. 【F:custom-features/queryVariablePlus.fs†L465-L497】
+5. **Reuse evaluation and highlighting behavior**
+   - New selections automatically benefit from the existing evaluation flow (`evaluateOnUse`, robust query batching, debug highlighting). Avoid adding special-case rendering; instead, rely on the shared plumbing unless the query builder truly requires it. 【F:custom-features/queryVariablePlus.fs†L499-L515】
+6. **Validate against the base feature**
+   - Confirm the new selection type is specific to Plus (or intentionally differs from the base) by comparing against the standard `queryVariable` file. This helps avoid regressions when future syncs occur. 【F:queryVariable.fs†L23-L187】
+
+## Tips for smooth integrations
+- Keep parameter names descriptive and aligned with existing patterns to maintain readability across features.
+- When a selection type can target different entity kinds (faces/edges/vertices), provide enums similar to `AdjacentResultType` and map them to concrete entity filters in a helper function.
+- Favor existing query constructors (`qAdjacent`, `qGeometry`, `qMatching`) where possible; wrap them only to add validation or defaulting behavior.
+
+Following this checklist keeps Query Variable Plus consistent with its current extensions while making future additions easy to review and maintain.


### PR DESCRIPTION
## Summary
- document how to add new selection types to Query Variable Plus using existing patterns
- highlight differences from the standard Query Variable feature to guide future extensions

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f113582e48332a9dd420f94b9e053)